### PR TITLE
Use SHA256 signature instead of SHA1

### DIFF
--- a/bin/cert-gen
+++ b/bin/cert-gen
@@ -272,6 +272,7 @@ fi
 # shellcheck disable=SC1117
 cmd="openssl x509 \
   -req \
+  -sha256
   -extensions v3_req \
   -extfile <(printf '[ req ]\nreq_extensions = v3_req\n[ v3_req ]\nsubjectAltName=${ALT_NAMES}\n') \
   -days ${DEF_DAYS} \


### PR DESCRIPTION
This fixes Chrome rejecting certificates due to an insecure signing method