### PR TITLE
Updating validity to align with requirements for Mac OS Catalina

### DIFF
--- a/bin/ca-gen
+++ b/bin/ca-gen
@@ -8,7 +8,7 @@ NAME="ca-gen"
 
 # Generate default options
 DEF_KEYSIZE=2048
-DEF_DAYS=3650
+DEF_DAYS=800
 # Subject default options
 DEF_COUNTRY=
 DEF_STATE=

--- a/bin/cert-gen
+++ b/bin/cert-gen
@@ -8,7 +8,7 @@ NAME="cert-gen"
 
 # Generate default options
 DEF_KEYSIZE=2048
-DEF_DAYS=3650
+DEF_DAYS=800
 # Subject default options
 DEF_COUNTRY=
 DEF_STATE=


### PR DESCRIPTION
I'm not sure if directly changing this makes sense as only a fraction of users may be affected, but I believe eventually Apples requirements for a shorter validity period may populate through other systems. 

If it makes more sense to create a configuration where individuals can override the DEF_DAYS parameter instead, feel free to deny this pull request. 

[Original issue](https://github.com/cytopia/devilbox/issues/640)
[Requirements for trusted certificates in iOS 13 and macOS 10.15 via Apple.com](https://support.apple.com/en-us/HT210176)